### PR TITLE
fix: follow tizentv conventions in the main and the index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/lib/index.js');
+module.exports = require('./build/lib/driver.js');

--- a/package.json
+++ b/package.json
@@ -20,13 +20,15 @@
   "license": "Apache-2.0",
   "author": "Jonathan Lipps <jlipps@headspin.io>",
   "types": "./build/lib/index.d.ts",
+  "main": "index.js",
+  "bin": {},
   "directories": {
     "lib": "lib"
   },
   "files": [
     "index.js",
     "lib",
-    "build"
+    "build/lib"
   ],
   "scripts": {
     "build": "run-p \"build:*\"",


### PR DESCRIPTION
Since https://github.com/headspinio/appium-lg-webos-driver/commit/bd6ce706d7b691fadc0c7859dca8aa3bc416bfed , this repository follows tizentv's conventions. So... should the index also be the driver.js?

Before:
```
[Appium] Could not load driver 'webos', so it will not be available. Error in loading the driver was: Cannot find module './build/lib/index.js'
[Appium] Require stack:
[Appium] - /Users/kazu/.appium/node_modules/appium-lg-webos-driver/index.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/extension/extension-config.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/extension-command.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/driver-command.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/extension.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/main.js
[Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/index.js
[debug] [Appium] Error: Cannot find module './build/lib/index.js'
[debug] [Appium] Require stack:
[debug] [Appium] - /Users/kazu/.appium/node_modules/appium-lg-webos-driver/index.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/extension/extension-config.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/extension-command.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/driver-command.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/cli/extension.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/build/lib/main.js
[debug] [Appium] - /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/index.js
[debug] [Appium]     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
[debug] [Appium]     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
[debug] [Appium]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[debug] [Appium]     at require (node:internal/modules/cjs/helpers:102:18)
[debug] [Appium]     at Object.<anonymous> (/Users/kazu/.appium/node_modules/appium-lg-webos-driver/index.js:1:18)
[debug] [Appium]     at Module._compile (node:internal/modules/cjs/loader:1105:14)
[debug] [Appium]     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
[debug] [Appium]     at Module.load (node:internal/modules/cjs/loader:981:32)
[debug] [Appium]     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[debug] [Appium]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[debug] [Appium]     at require (node:internal/modules/cjs/helpers:102:18)
[debug] [Appium]     at DriverConfig.require (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/extension-config.js:535:23)
[debug] [Appium]     at map (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/index.js:83:46)
[debug] [Appium]     at Array.map (<anonymous>)
[debug] [Appium]     at getActiveDrivers (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/index.js:80:10)
[debug] [Appium]     at main (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/main.js:305:25)
```

After:
```
[debug] [Appium] Requiring driver at /Users/kazu/.appium/node_modules/appium-lg-webos-driver
[Appium] Could not load driver 'webos', so it will not be available. Error in loading the driver was: Ensure the "LG_WEBOS_TV_SDK_HOME" environment variable
[Appium] is set; see https://webostv.developer.lge.com/sdk/command-line-interface/installation/
[Appium] for more information
[debug] [Appium] Error: Ensure the "LG_WEBOS_TV_SDK_HOME" environment variable
[debug] [Appium] is set; see https://webostv.developer.lge.com/sdk/command-line-interface/installation/
[debug] [Appium] for more information
[debug] [Appium]     at Object.<anonymous> (/Users/kazu/GitHub/appium-lg-webos-driver/lib/cli/ares.js:24:9)
[debug] [Appium]     at Module._compile (node:internal/modules/cjs/loader:1105:14)
[debug] [Appium]     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
[debug] [Appium]     at Module.load (node:internal/modules/cjs/loader:981:32)
[debug] [Appium]     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[debug] [Appium]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[debug] [Appium]     at require (node:internal/modules/cjs/helpers:102:18)
[debug] [Appium]     at Object.<anonymous> (/Users/kazu/GitHub/appium-lg-webos-driver/lib/driver.js:4:1)
[debug] [Appium]     at Module._compile (node:internal/modules/cjs/loader:1105:14)
[debug] [Appium]     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
[debug] [Appium]     at Module.load (node:internal/modules/cjs/loader:981:32)
[debug] [Appium]     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[debug] [Appium]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[debug] [Appium]     at require (node:internal/modules/cjs/helpers:102:18)
[debug] [Appium]     at Object.<anonymous> (/Users/kazu/GitHub/appium-lg-webos-driver/index.js:1:18)
[debug] [Appium]     at Module._compile (node:internal/modules/cjs/loader:1105:14)
[debug] [Appium]     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
[debug] [Appium]     at Module.load (node:internal/modules/cjs/loader:981:32)
[debug] [Appium]     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[debug] [Appium]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[debug] [Appium]     at require (node:internal/modules/cjs/helpers:102:18)
[debug] [Appium]     at DriverConfig.require (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/extension-config.js:535:23)
[debug] [Appium]     at map (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/index.js:83:46)
[debug] [Appium]     at Array.map (<anonymous>)
[debug] [Appium]     at getActiveDrivers (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/extension/index.js:80:10)
[debug] [Appium]     at main (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/lib/main.js:305:25)
```

with `LG_WEBOS_TV_SDK_HOME`
```
[Appium] Welcome to Appium v2.0.0-beta.46 (REV 011810e721c4c26be997c7c0b62739c7b991526d)
[Appium] Attempting to load driver uiautomator2...
[debug] [Appium] Requiring driver at /Users/kazu/.appium/node_modules/appium-uiautomator2-driver
[Appium] Attempting to load driver webos...
[debug] [Appium] Requiring driver at /Users/kazu/.appium/node_modules/appium-lg-webos-driver
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
[Appium] Available drivers:
[Appium]   - uiautomator2@2.9.0 (automationName 'UiAutomator2')
[Appium]   - webos@0.0.1 (automationName 'webOS')
[Appium] Available plugins:
```