### PR TITLE
fix: launch devmode app post session to keep tv awake

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -20,6 +20,10 @@ import {LGRemoteKeys} from './remote/lg-remote-client';
 import {LGWSClient} from './remote/lg-socket-client';
 export {KEYS} from './keys';
 
+// this is the ID for the 'Developer' application, which we launch after a session ends to ensure
+// some app stays running (otherwise the TV might shut off)
+const DEV_MODE_ID = 'com.palmdts.devmode';
+
 // don't proxy any 'appium' routes
 /** @type {RouteMatcher[]} */
 const NO_PROXY = [
@@ -246,9 +250,9 @@ export class WebOSDriver extends BaseDriver {
     await closeApp(this.opts.appId, this.opts.deviceName);
 
     if (this.remoteClient) {
-      log.info(`Pressing HOME twice to prevent 15 min auto off after app exit`);
+      log.info(`Pressing HOME and launching dev app to prevent auto off`);
       await this.remoteClient.pressKey(LGRemoteKeys.HOME);
-      await this.remoteClient.pressKey(LGRemoteKeys.HOME);
+      await launchApp(DEV_MODE_ID, this.opts.deviceName);
     }
 
     if (this.socketClient) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "husky install && npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 40s --slow 10s \"./test/e2e/**/*.spec.js\"",
-    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
+    "test:unit": "mocha --timeout 5s \"./test/unit/**/*.spec.js\""
   },
   "lint-staged": {
     "*.{md,yml,ts}": [


### PR DESCRIPTION
so far my overnight stress tests have shown that simply pressing the home button isn't enough. we need to launch some app and have it be active. the dev mode app seems the safest one to launch since we know it's always there.