### PR TITLE
feat: add a generic per-device key store

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -8,18 +8,19 @@ module.exports = (wallaby) => {
         allowSyntheticDefaultImports: true,
         resolveJsonModule: true,
         isolatedModules: true,
-      })
+      }),
+      '**/*.ts?(x)': wallaby.compilers.typeScript(),
     },
     debug: true,
     env: {
       type: 'node',
     },
     files: [
-      './lib/**/*.js'
+      './lib/**/*.{js,ts}'
     ],
     testFramework: 'mocha',
     tests: [
-      './test/unit/**/*.spec.js',
+      './test/unit/**/*.spec.{js,ts}',
     ],
     runMode: 'onsave',
     workers: {recycle: true},

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -18,6 +18,8 @@ import {KEYMAP} from './keys';
 import log from './logger';
 import {LGRemoteKeys} from './remote/lg-remote-client';
 import {LGWSClient} from './remote/lg-socket-client';
+// eslint-disable-next-line import/no-unresolved
+import {ValueBox} from './remote/valuebox';
 export {KEYS} from './keys';
 
 // this is the ID for the 'Developer' application, which we launch after a session ends to ensure
@@ -131,7 +133,10 @@ export class WebOSDriver extends BaseDriver {
       await installApp(app, appId, deviceName);
     }
 
+    this.valueBox = ValueBox.create('appium-lg-webos-driver');
     this.socketClient = new LGWSClient({
+      valueBox: this.valueBox,
+      deviceName,
       url: `ws://${deviceHost}:${websocketPort}`,
       remoteKeyCooldown: keyCooldown,
     });

--- a/lib/remote/lg-socket-client.js
+++ b/lib/remote/lg-socket-client.js
@@ -1,10 +1,8 @@
-import envPaths from 'env-paths';
 import WebSocket from 'ws';
 import B from 'bluebird';
 import {AUTH_PAYLOAD, MsgType} from './constants';
 import {logger} from 'appium/support';
 import path from 'path';
-import fs from 'fs/promises';
 import {LGRemoteClient} from './lg-remote-client';
 
 export const WsEvent = /** @type {const} */ ({
@@ -15,21 +13,12 @@ export const WsEvent = /** @type {const} */ ({
   MESSAGE: 'message',
 });
 
-const KEY_STORAGE_DIR = envPaths('appium-lg-webos-driver').data;
-const DEFAULT_CLIENT_KEY_FILE = path.join(KEY_STORAGE_DIR, 'client-key.txt');
-
 export class LGWSClient {
   /** @type {string} */
   #url;
 
   /** @type {WebSocket|undefined} */
   #ws;
-
-  /** @type {string|undefined} */
-  #clientKey;
-
-  /** @type {string} */
-  #clientKeyFile;
 
   /** @type {boolean} */
   #saveClientKey;
@@ -46,23 +35,41 @@ export class LGWSClient {
   #remoteKeyCooldown;
 
   /**
+   * @type {import('./valuebox').ValueWrapper<string>}
+   */
+  #keystore;
+
+  /** @type {import('./valuebox').ValueBox} */
+  #valueBox;
+
+  /**
+   * Unique identifier for key based on device name.
+   * Also doubles as a filename.
+   * @type {string}
+   */
+  #keystoreId;
+
+  /** @type {string|undefined} */
+  #clientKey;
+
+  /**
    *
    * @param {import('../types').LGSocketClientOpts} opts
    */
   constructor({
     url,
-    clientKey,
+    valueBox,
+    deviceName,
     log = logger.getLogger('LGWsClient'),
-    clientKeyFile = DEFAULT_CLIENT_KEY_FILE,
     saveClientKey = true,
     remoteKeyCooldown,
   }) {
+    this.#valueBox = valueBox;
     this.#url = url;
-    this.#clientKey = clientKey;
     this.#log = log;
-    this.#clientKeyFile = clientKeyFile;
     this.#saveClientKey = saveClientKey;
     this.#remoteKeyCooldown = remoteKeyCooldown;
+    this.#keystoreId = `clientKey-${deviceName}.txt`;
   }
 
   /**
@@ -127,7 +134,7 @@ export class LGWSClient {
         try {
           res(JSON.parse(msg));
         } catch (err) {
-          onError(/** @type {Error} */(err));
+          onError(/** @type {Error} */ (err));
         }
       };
       /** @param {Error} err */
@@ -166,14 +173,28 @@ export class LGWSClient {
   }
 
   /**
+   * Gets / initializes the keystore based on the keystore ID
+   * @see {@linkcode #keystoreId}
+   * @returns {Promise<import('./valuebox').ValueWrapper<string>>}
+   */
+  async #getKeystore() {
+    return (
+      this.#keystore ?? (this.#keystore = await this.#valueBox.createWrapper(this.#keystoreId))
+    );
+  }
+
+  /**
    *
    * @returns {Promise<string>}
    */
   async authenticate() {
     if (this.#saveClientKey) {
-      this.#log.info(`Trying to read key from file on disk at ${this.#clientKeyFile}`);
       try {
-        this.#clientKey = await fs.readFile(this.#clientKeyFile, 'utf8');
+        const keystore = await this.#getKeystore();
+        this.#log.info(
+          `Trying to read key from file on disk at ${path.join(this.#valueBox.dir, keystore.id)}`
+        );
+        this.#clientKey = keystore.value;
         this.#log.info(`Success: key is '${this.#clientKey}'`);
       } catch (ign) {
         this.#log.info(`Could not read key from disk`);
@@ -191,10 +212,10 @@ export class LGWSClient {
         throw new Error('Could not authenticate, please accept prompt');
       }
     }
-    if (this.#saveClientKey && this.#clientKey !== origClientKey) {
+    if (this.#saveClientKey && this.#clientKey !== undefined && this.#clientKey !== origClientKey) {
       this.#log.info(`Client key changed, writing it to disk`);
-      await fs.mkdir(KEY_STORAGE_DIR, {recursive: true});
-      await fs.writeFile(this.#clientKeyFile, /** @type {string} */ (this.#clientKey), 'utf8');
+      const keystore = await this.#getKeystore();
+      await keystore.put(this.#clientKey);
     }
     return /** @type {string} */ (this.#clientKey);
   }
@@ -276,7 +297,7 @@ export class LGWSClient {
    * @param {P} [payload]
    * @returns {Promise<R|undefined>}
    */
-  async request(uri, payload = /** @type {P} */({})) {
+  async request(uri, payload = /** @type {P} */ ({})) {
     if (!this.#clientKey) {
       throw new Error(`Can't send request without client key set`);
     }

--- a/lib/remote/valuebox.ts
+++ b/lib/remote/valuebox.ts
@@ -1,0 +1,327 @@
+import envPaths from 'env-paths';
+import {readFile, writeFile, mkdir, unlink, rm} from 'node:fs/promises';
+import slugify from 'slugify';
+import path from 'node:path';
+
+export type ValueEncoding = BufferEncoding | null;
+export type Value = string | Buffer;
+/**
+ * Represents a "value", which is just a file on disk containing something.
+ *
+ * A {@linkcode ValueWrapper} does not know anything about where it is stored, or how it is stored.
+ */
+export interface ValueWrapper<V extends Value> {
+  /**
+   * Slugified name
+   */
+  id: string;
+  /**
+   * Name of value
+   */
+  name: string;
+
+  /**
+   * Encoding of value
+   */
+  encoding: ValueEncoding;
+  /**
+   * Read value from disk
+   */
+  look(): Promise<V>;
+  /**
+   * Write to value
+   * @param value New value to write to value
+   */
+  put(value: V): Promise<void>;
+
+  /**
+   * Current value, if any
+   */
+  get value(): V | undefined;
+}
+
+/**
+ * A function which reads from a value
+ */
+export interface ValueLooker<V extends Value> {
+  (value: ValueWrapper<V>): Promise<V>;
+}
+/**
+ * A function which writes to a value
+ */
+export interface ValuePutter<V extends Value> {
+  (value: ValueWrapper<V>, data: V): Promise<void>;
+}
+
+/**
+ * A value which stores its value in a file on disk
+ *
+ * This class is not intended to be instantiated directly
+ *
+ */
+export class BaseValueWrapper<V extends Value> implements ValueWrapper<V> {
+  /**
+   * Underlying value
+   */
+  #value: V | undefined;
+
+  /**
+   * Slugified name
+   */
+  public readonly id: string;
+  /**
+   * Function which reads a value
+   */
+  private readonly looker: ValueLooker<V>;
+  /**
+   * Function which writes a value
+   */
+  private readonly putter: ValuePutter<V>;
+
+  /**
+   * Underlying value
+   */
+  public readonly value: V;
+
+  /**
+   * Slugifies the name
+   * @param name Name of value
+   * @param looker Reader fn
+   * @param putter Writer fn
+   * @param encoding Defaults to `utf8`
+   */
+  constructor(
+    public readonly name: string,
+    looker: ValueLooker<V>,
+    putter: ValuePutter<V>,
+    public readonly encoding: ValueEncoding = 'utf8'
+  ) {
+    this.id = slugify(name, {lower: true});
+
+    Object.defineProperties(this, {
+      looker: {value: looker},
+      putter: {value: putter},
+      value: {
+        get() {
+          return this.#value;
+        },
+        enumerable: true,
+      },
+    });
+  }
+
+  /**
+   * {@inheritdoc IValueWrapper.read}
+   */
+  async look(): Promise<V> {
+    this.#value = await this.looker(this);
+    return this.#value;
+  }
+
+  /**
+   * {@inheritdoc IValueWrapper.write}
+   */
+  async put(value: V): Promise<void> {
+    await this.putter(this, value);
+    this.#value = value;
+  }
+}
+
+/**
+ * @see {@linkcode ValueBoxOpts}
+ */
+export const DEFAULT_SUFFIX = 'valuebox';
+
+/**
+ * A class which instantiates a {@linkcode ValueWrapper}.
+ */
+export interface ValueConstructor<V extends Value> {
+  new (
+    name: string,
+    reader: ValueLooker<V>,
+    writer: ValuePutter<V>,
+    encoding?: ValueEncoding
+  ): ValueWrapper<V>;
+}
+
+/**
+ * Main entry point for use of this module
+ *
+ * Manages multiple values.
+ */
+export class ValueBox {
+  /**
+   * Slugified name of this container; corresponds to the directory name.
+   *
+   * If `dir` is provided, this value is unused.
+   * If `suffix` is provided, then this will be the parent directory of `suffix`.
+   */
+  public readonly containerId: string;
+  /**
+   * Override the directory of this container.
+   *
+   * If this is present, both `suffix` and `containerId` are unused.
+   */
+  public readonly dir: string;
+
+  protected ctor?: ValueConstructor<any>;
+
+  /**
+   * Factory function for creating new {@linkcode ValueWrapper}s}
+   */
+  protected wrapperIds: Set<string> = new Set();
+
+  protected constructor(
+    public readonly name: string,
+    {dir, suffix = DEFAULT_SUFFIX, defaultCtor: ctor = BaseValueWrapper}: ValueBoxOpts = {}
+  ) {
+    this.containerId = slugify(name, {lower: true});
+    this.ctor = ctor;
+    this.dir = dir ?? path.join(envPaths(this.containerId).data, suffix);
+  }
+
+  /**
+   * "mkdirp"'s the value directory and writes it to disk
+   * @param value ValueWrapper to write
+   * @param value Value to write to the value
+   */
+  private async put<V extends Value>(wrapper: ValueWrapper<V>, value: string): Promise<void> {
+    await this.init();
+    await writeFile(path.join(this.dir, wrapper.id), value, wrapper.encoding);
+  }
+
+  /**
+   * "mkdirp"'s the value directory
+   */
+  private async init(): Promise<void> {
+    await mkdir(this.dir, {recursive: true});
+  }
+
+  /**
+   * Removes _all_ values from disk by truncating the value directory.
+   *
+   * Convniently removes everything else in the value directory, even if it isn't a value!
+   */
+  public async recycleAll() {
+    try {
+      await rm(this.dir, {recursive: true, force: true});
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw e;
+      }
+    }
+  }
+  /**
+   * Reads a value in a value from disk
+   * @param value ValueWrapper to read
+   */
+  protected async look<V extends Value>(wrapper: ValueWrapper<V>): Promise<V | undefined> {
+    try {
+      return (await readFile(path.join(this.dir, wrapper.id), {
+        encoding: wrapper.encoding,
+      })) as V;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Removes a value from disk.
+   *
+   * This does _not_ destroy the `ValueWrapper` instance in memory, nor does it allow the `id` to be reused.
+   * @param wrapper ValueWrapper to drop
+   */
+  async recycle(wrapper: ValueWrapper<Value>) {
+    try {
+      await unlink(path.join(this.dir, wrapper.id));
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create a new {@linkcode ValueWrapper}. Reads the value from disk, if present.
+   * @param name Name of value
+   * @param encoding Encoding of value; defaults to `utf8`
+   * @returns New value
+   */
+  async createWrapper<V extends Value>(
+    name: string,
+    encoding?: ValueEncoding
+  ): Promise<ValueWrapper<V>> {
+    const wrapper = new (this.ctor as ValueConstructor<V>)(
+      name,
+      this.look.bind(this),
+      this.put.bind(this),
+      encoding
+    );
+    if (this.wrapperIds.has(wrapper.id)) {
+      throw new Error(`ValueWrapper with id "${wrapper.id}" already exists`);
+    }
+    try {
+      await wrapper.look();
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw e;
+      }
+    }
+    this.wrapperIds.add(wrapper.id);
+    return wrapper;
+  }
+
+  /**
+   * Creates a {@linkcode ValueWrapper} then immediately writes a value to it.
+   * If there was anything on disk, it is overwritten.
+   * @param name Name of value
+   * @param value Value to write
+   * @returns New `ValueWrapper` w/ value of `value`
+   */
+  async createWrapperWithValue<V extends Value>(
+    name: string,
+    value: V,
+    encoding?: ValueEncoding
+  ): Promise<ValueWrapper<V>> {
+    const wrapper = await this.createWrapper<V>(name, encoding);
+    await wrapper.put(value);
+    return wrapper;
+  }
+
+  /**
+   * Creates a new {@linkcode ValueBox}
+   * @param name Name of value container
+   * @param opts Options
+   * @returns New value
+   */
+  static create(name: string, opts?: ValueBoxOpts) {
+    return new ValueBox(name, opts);
+  }
+}
+
+export interface ValueBox {
+  /**
+   * Creates a new {@linkcode ValueBox}
+   * @param name Name of value container
+   * @param opts Options
+   * @returns New value
+   */
+  create(name: string, opts?: ValueBoxOpts): ValueBox;
+}
+
+export interface ValueBoxOpts {
+  /**
+   * Override default value directory, which is chosen according to environment
+   */
+  dir?: string;
+
+  /**
+   * Extra subdir to append to the auto-generated value directory. Ignored if `dir` is a `string`.
+   * @defaultValue 'valuebox'
+   */
+  suffix?: string;
+
+  defaultCtor?: ValueConstructor<any>;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,8 @@
-import { AppiumLogger } from '@appium/types';
+import {AppiumLogger} from '@appium/types';
 import {JsonPrimitive, SetRequired, Writable} from 'type-fest';
-import { KnownKey } from './keys';
-import { AuthPayload, MessageType } from './remote/constants';
+import {KnownKey} from './keys';
+import {AuthPayload, MessageType} from './remote/constants';
+import {ValueBox} from './remote/valuebox';
 
 /**
  * Extra caps that cannot be inferred from constraints.
@@ -17,7 +18,7 @@ export interface InboundMsg<P extends SerializableObject = any> extends Outbound
   error?: string;
 }
 
-export interface OutboundMsg<P extends SerializableObject|void = void> {
+export interface OutboundMsg<P extends SerializableObject | void = void> {
   id: `${MessageType}_${number}`;
   type: MessageType;
   uri?: string;
@@ -25,16 +26,16 @@ export interface OutboundMsg<P extends SerializableObject|void = void> {
 }
 
 export interface PromptMsg extends InboundMsg<{pairingType: 'PROMPT'}> {
-  type: 'response'
+  type: 'response';
 }
 
 export interface RegisteredMsg extends InboundMsg<SetRequired<AuthPayload, 'client-key'>> {
-  type: 'registered'
+  type: 'registered';
 }
 
 /**
  * A plain object which can be serialized to JSON.
- * 
+ *
  * Makes readonly types writable.
  */
 export type SerializableObject = {
@@ -71,7 +72,9 @@ export interface PressKeyOptions {
 }
 
 export interface LGSocketClientOpts {
+  deviceName: string;
   url: string;
+  valueBox: ValueBox;
   clientKey?: string;
   log?: AppiumLogger;
   clientKeyFile?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "env-paths": "2.2.1",
         "get-port": "^5.1.1",
         "lodash": "^4.17.21",
+        "slugify": "1.6.5",
         "teen_process": "^1.9.0",
         "ws": "^8.8.1"
       },
@@ -54,8 +55,8 @@
         "webdriverio": "7.25.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.40"
@@ -9720,6 +9721,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18639,6 +18648,11 @@
           "dev": true
         }
       }
+    },
+    "slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "env-paths": "2.2.1",
     "get-port": "^5.1.1",
     "lodash": "^4.17.21",
+    "slugify": "1.6.5",
     "teen_process": "^1.9.0",
     "ws": "^8.8.1"
   },

--- a/test/unit/valuebox.spec.ts
+++ b/test/unit/valuebox.spec.ts
@@ -1,0 +1,197 @@
+import path from 'node:path';
+import rewiremock from 'rewiremock/node';
+import type {ValueBox, ValueWrapper} from '../../lib/remote/valuebox';
+import {createSandbox, SinonSandbox, SinonStubbedMember} from 'sinon';
+import type fs from 'node:fs/promises';
+
+const {expect} = chai;
+type MockFs = {
+  [K in keyof typeof fs]: SinonStubbedMember<typeof fs[K]>;
+};
+
+describe('ValueBox', function () {
+  let ValueBox: ValueBox;
+  let sandbox: SinonSandbox;
+  let DEFAULT_SUFFIX: string;
+  let MockFs: MockFs = {} as any;
+
+  const DATA_DIR = '/some/dir';
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+    ({ValueBox, DEFAULT_SUFFIX} = rewiremock.proxy(
+      () => require('../../lib/remote/valuebox'),
+      (r) => ({
+        // all of these props are async functions
+        'node:fs/promises': r
+          .mockThrough((prop) => {
+            MockFs[prop] = sandbox.stub().resolves();
+            return MockFs[prop];
+          })
+          .dynamic(), // this allows us to change the mock behavior on-the-fly
+        'env-paths': sandbox.stub().returns({data: DATA_DIR}),
+      })
+    ));
+  });
+
+  describe('static method', function () {
+    describe('create()', function () {
+      it('should return a new ValueBox', function () {
+        const valueBox = ValueBox.create('test');
+        expect(valueBox).to.be.an.instanceOf(ValueBox);
+      });
+    });
+  });
+
+  describe('instance method', function () {
+    let valueBox: ValueBox;
+
+    beforeEach(function () {
+      valueBox = ValueBox.create('test');
+    });
+
+    describe('createWrapper()', function () {
+      describe('when a ValueWrapper with the same id does not exist', function () {
+        describe('when the file does not exist', function () {
+          it('should create an empty ValueWrapper', async function () {
+            const wrapper = await valueBox.createWrapper('SLUG test');
+            expect(wrapper).to.eql({
+              id: 'slug-test',
+              name: 'SLUG test',
+              encoding: 'utf8',
+              value: undefined,
+            });
+          });
+        });
+
+        describe('when the file exists', function () {
+          beforeEach(function () {
+            MockFs.readFile.resolves('foo bar');
+          });
+          it('should read its value', async function () {
+            const wrapper = await valueBox.createWrapper('SLUG test');
+            expect(wrapper).to.eql({
+              id: 'slug-test',
+              name: 'SLUG test',
+              encoding: 'utf8',
+              value: 'foo bar',
+            });
+          });
+        });
+
+        describe('when a value is written to the ValueWrapper', function () {
+          it('should write a string value to the underlying file', async function () {
+            const wrapper = await valueBox.createWrapper('test');
+            await wrapper.put('boo bah');
+
+            expect(MockFs.writeFile).to.have.been.calledWith(
+              path.join(DATA_DIR, DEFAULT_SUFFIX, 'test'),
+              'boo bah',
+              'utf8'
+            );
+          });
+
+          it('should update the underlying value', async function () {
+            const wrapper = await valueBox.createWrapper('test');
+            await wrapper.put('boo bah');
+            expect(wrapper.value).to.equal('boo bah');
+          });
+        });
+      });
+
+      describe('when a ValueWrapper with the same id already exists', function () {
+        it('should throw an error', async function () {
+          await valueBox.createWrapper('test');
+          await expect(valueBox.createWrapper('test')).to.be.rejectedWith(
+            Error,
+            'ValueWrapper with id "test" already exists'
+          );
+        });
+      });
+    });
+
+    describe('recycle()', function () {
+      it('should attempt to unlink the underlying file', async function () {
+        const wrapper = await valueBox.createWrapper('test');
+        await valueBox.recycle(wrapper);
+        expect(MockFs.unlink).to.have.been.calledWith(path.join(DATA_DIR, DEFAULT_SUFFIX, 'test'));
+      });
+
+      describe('when the underlying file does not exist', function () {
+        beforeEach(function () {
+          MockFs.unlink.rejects(Object.assign(new Error(), {code: 'ENOENT'}));
+        });
+
+        it('should not reject', async function () {
+          const wrapper = await valueBox.createWrapper('test');
+          await expect(valueBox.recycle(wrapper)).to.eventually.be.undefined;
+        });
+
+        it('should call unlink with the correct path', async function () {
+          await valueBox.recycle(await valueBox.createWrapper('test'));
+          expect(MockFs.unlink).to.have.been.calledOnceWith('/some/dir/valuebox/test');
+        });
+      });
+
+      describe('when there is some other error', function () {
+        beforeEach(function () {
+          MockFs.unlink.rejects(Object.assign(new Error(), {code: 'ETOOMANYGOATS'}));
+        });
+
+        it('should reject', async function () {
+          const wrapper = await valueBox.createWrapper('test');
+          await expect(valueBox.recycle(wrapper)).to.be.rejected;
+        });
+      });
+    });
+
+    describe('recycleAll()', function () {
+      describe('when the underlying dir does not exist', function () {
+        beforeEach(function () {
+          MockFs.rm.rejects(Object.assign(new Error(), {code: 'ENOENT'}));
+        });
+
+        it('should not reject', async function () {
+          await expect(valueBox.recycleAll()).to.eventually.be.undefined;
+        });
+
+        it('should call rm with the correct path', async function () {
+          await valueBox.recycleAll();
+          expect(MockFs.rm).to.have.been.calledOnceWith('/some/dir/valuebox', {
+            recursive: true,
+            force: true,
+          });
+        });
+      });
+
+      describe('when there is some other error', function () {
+        beforeEach(function () {
+          MockFs.rm.rejects(Object.assign(new Error(), {code: 'ETOOMANYGOATS'}));
+        });
+
+        it('should reject', async function () {
+          await expect(valueBox.recycleAll()).to.be.rejected;
+        });
+      });
+    });
+
+    describe('createWrapperWithValue()', function () {
+      it('should create a ValueWrapper with the given value', async function () {
+        const wrapper = await valueBox.createWrapperWithValue('test', 'value');
+        expect(wrapper.value).to.equal('value');
+      });
+
+      it('should write the value to disk', async function () {
+        await valueBox.createWrapperWithValue('test', 'value');
+        expect(MockFs.writeFile).to.have.been.calledWith(
+          path.join(DATA_DIR, DEFAULT_SUFFIX, 'test'),
+          'value'
+        );
+      });
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+});


### PR DESCRIPTION
This change adds a couple very generic classes which handle creating and reading uniquely-identifiable files.

A `ValueBox` is a "container", which may correspond to a module or package, and has a 1:1 relationship with a particular directory on disk. A `ValueWrapper` corresponds to a file in this container (directory) _and_ the contents of the file.  The file contents can be of any encoding supported by Node.js' `Buffer` (including `null`, which is just a `Buffer`).

It should be easily adaptable to reuse in other Appium projects, and/or within Appium itself.