### PR TITLE
docs: update platformname and automationname

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ package in your `package.json`)
 
 |Capability|Description|
 |----------|-----------|
-|`platformName`|[Required] Must be `LGTV`|
-|`appium:automationName`|[Required] Must be `webOS`|
+|`platformName`|[Required] Must be `lgtv`|
+|`appium:automationName`|[Required] Must be `webos`|
 |`appium:deviceName`|[Required] The name of the connected device, as it shows up in `ares-launch --device-list`|
 |`appium:deviceHost`|[Required] The IP address of the connected device, as it shows up in `ares-launch --device-list`|
 |`appium:appId`|[Required] The app package ID, if you want Appium to use an app already on the TV. Exclusive with `appium:app`|


### PR DESCRIPTION
> "platformName"
[Lowercase](https://www.w3.org/TR/webdriver1/#dfn-lowercase) name of the current platform as a [string](https://www.w3.org/TR/webdriver1/#dfn-string).

https://www.w3.org/TR/webdriver1/

So, the capabilities are also nice to address lowercase. automationName is also. (Appium's internal handles as lower case, so it should not be matter)