### PR TITLE
chore: leave log message if no browser info was found

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -202,9 +202,20 @@ export class WebOSDriver extends BaseDriver {
 
 
   /**
+   * @typedef BrowserVersionInfo
+   * @property {string} Browser
+   * @property {string} Protocol-Version
+   * @property {string} User-Agent
+   * @property {string} V8-Version
+   * @property {string} WebKit-Version
+   * @property {string} webSocketDebuggerUrl
+   */
+
+  /**
    * Use UserAgent info for "Browser" if the chrome response did not include
    * browser name properly.
-   * @param {object} browserVersionInfo
+   * @param {BrowserVersionInfo} browserVersionInfo
+   * @return {BrowserVersionInfo}
    */
   useUAForBrowserIfNotPresent(browserVersionInfo) {
     if (!_.isEmpty(browserVersionInfo.Browser)) {
@@ -222,6 +233,7 @@ export class WebOSDriver extends BaseDriver {
     }
 
     log.info(`The response did not have Browser, thus set the Browser value from UA as ${JSON.stringify(browserVersionInfo)}`);
+    // @ts-ignore isEmpty already checked as null.
     browserVersionInfo.Browser = chromeVersion[0];
     return browserVersionInfo;
   }
@@ -258,9 +270,13 @@ export class WebOSDriver extends BaseDriver {
 
         // To respect the executableDir.
         executable = undefined;
+
+        if (_.isEmpty(result.Browser)) {
+          this.log.info(`No browser version info was available. If no proper chromedrivers exist in ${executableDir}, the session creation will fail.`);
+        }
       } catch (err) {
         throw new errors.SessionNotCreatedError(
-          `Could not get the chrome browser information to detect proper chromedriver version. Is it a debiggable build? Error: ${err.message}`
+          `Could not get the chrome browser information to detect proper chromedriver version. Is it a debuggable build? Error: ${err.message}`
         );
       }
     }


### PR DESCRIPTION
Closes https://github.com/headspinio/appium-lg-webos-driver/issues/50

Error response itself will be generated by `new Chromedriver({`. It would be nice to leave a possible failure message as an appium server log to leave a hint.