### PR TITLE
docs: update ares-device syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ package in your `package.json`)
 - You must have an LG webOS TV device on the same network as your Appium host, with all ports accessible to the network
 - The TV must be in [Developer Mode](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app) (must have the Dev Mode app and be signed in, with Dev Mode actually turned "On" in the app)
 - You must have your TV device set up and showing as available using the [`ares-setup-device`](https://www.webosose.org/docs/tools/sdk/cli/cli-user-guide/#ares-setup-device) CLI tool
-- You should be able to run `ares-device-info --device <name>` and have it show the correct details for your connected device
+- You should be able to run `ares-device -i -d <name>` and have it show the correct details for your connected device
 - The first time you run an Appium session, the driver will attempt to pair itself with the TV as a remote. A permission popup will appear that you need to interact with. You should only need to do this once. If the driver is reinstalled, its permission token cache is removed, or the TV is updated (and potentially even some other circumstances) re-pairing might be necessary.
 
 ## Capabilities


### PR DESCRIPTION
This fixes an error:
```
ares-device-info ERR! [Tips]: This command is deprecated. Please use "ares-device" instead of "ares-device-info" 
```