### PR TITLE
fix: use mini version if no browser info was given

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -253,9 +253,10 @@ export class WebOSDriver extends BaseDriver {
 
   /**
    * Set chrome version v63.0.3239.0 as the minimal version
-   * for autodownload to use proper chromedriver version.
-   * Older than the chromedriver version could raise no Chrome binary found error,
-   * which no makes sense for TV automation usage.
+   * for autodownload to use proper chromedriver version if
+   *     - the 'Browser' info does not have proper chrome version, or
+   *     - older than the chromedriver version could raise no Chrome binary found error,
+   *       which no makes sense for TV automation usage.
    *
    * @param {BrowserVersionInfo} browserVersionInfo
    * @return {BrowserVersionInfo}
@@ -263,6 +264,7 @@ export class WebOSDriver extends BaseDriver {
   fixChromeVersionForAutodownload(browserVersionInfo) {
     const chromeVersion = VERSION_PATTERN.exec(browserVersionInfo.Browser ?? '');
     if (!chromeVersion) {
+      browserVersionInfo.Browser = MIN_CHROME_VERSION;
       return browserVersionInfo;
     }
 
@@ -307,6 +309,7 @@ export class WebOSDriver extends BaseDriver {
         log.info(`The response of http://${debuggerAddress}/json/version was ${JSON.stringify(result)}`);
         result = this.useUAForBrowserIfNotPresent(result);
         result = this.fixChromeVersionForAutodownload(result);
+        log.info(`Fixed browser info is ${JSON.stringify(result)}`);
 
         // To respect the executableDir.
         executable = undefined;

--- a/test/unit/driver.spec.js
+++ b/test/unit/driver.spec.js
@@ -139,13 +139,16 @@ describe('WebOSDriver', function () {
       const driver = new WebOSDriver();
       const browserInfo = {
         'Browser': '',
-        'Protocol-Version': '1.3',
-        'User-Agent': 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36',
-        'V8-Version': '8.7.220.(29*1000 + 2)',
-        'WebKit-Version': '537.36 (@cec52f3dd4465dd7389298b97ab723856c556bd)',
-        'webSocketDebuggerUrl': 'ws://192.168.0.1:9998/devtools/browser/a4b3786c-2d2f-4751-9e05-aee2023bc226'
+        'Protocol-Version': '1.1',
+        'User-Agent': '',
+        'WebKit-Version': '537.36 (@fa89da905405aab455e0f0d4ec7f49631c7ca70b)'
       };
-      driver.fixChromeVersionForAutodownload(browserInfo).should.eql(browserInfo);
+      driver.fixChromeVersionForAutodownload(browserInfo).should.eql({
+        'Browser': 'Chrome/63.0.3239.0',
+        'Protocol-Version': '1.1',
+        'User-Agent': '',
+        'WebKit-Version': '537.36 (@fa89da905405aab455e0f0d4ec7f49631c7ca70b)'
+      });
     });
 
     it('Use the given chrome version', function () {


### PR DESCRIPTION
We observed non browser/ua case. Then let's set the mini browser version.

This is currently LG TV specific thing.